### PR TITLE
fix: don't hoist defaultProps

### DIFF
--- a/src/__fixtures__/SimpleField.tsx
+++ b/src/__fixtures__/SimpleField.tsx
@@ -6,6 +6,10 @@ const Description = (props: React.ComponentPropsWithoutRef<'span'>) => (
   <span {...props} />
 )
 
+Description.defaultProps = {
+  'data-testid': 'description',
+}
+
 const FieldLabel = createSlot<'label'>()
 const FieldInput = createSlot('input')
 const FieldDescription = createSlot(Object.assign(Description, { foo: 'Foo' }))

--- a/src/__tests__/simple.test.tsx
+++ b/src/__tests__/simple.test.tsx
@@ -251,7 +251,9 @@ test('without host', () => {
 
   instance.update(<Field.Description>Description</Field.Description>)
   expect(instance).toMatchInlineSnapshot(`
-    <span>
+    <span
+      data-testid="description"
+    >
       Description
     </span>
   `)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export const getComponentName = (Component: React.ElementType) => {
   return Component.displayName || Component.name || 'Component'
 }
 
-const REACT_STATICS = ['$$typeof', 'render', 'displayName']
+const REACT_STATICS = ['$$typeof', 'render', 'displayName', 'defaultProps']
 
 export const hoistStatics = <T extends React.ElementType>(
   target: T,


### PR DESCRIPTION
The problem: `defaultProps` will be merged to `slotElement.props` but we only want props from user input